### PR TITLE
Workaround quirk in CS:GO

### DIFF
--- a/src/main/java/nl/vv32/rcon/Packet.java
+++ b/src/main/java/nl/vv32/rcon/Packet.java
@@ -13,6 +13,10 @@ public class Packet {
         this.payload = payload;
     }
 
+    public Packet(final int requestId, final int type) {
+        this(requestId, type, "");
+    }
+
     public boolean isValid() {
         return requestId != -1;
     }

--- a/src/test/java/nl/vv32/rcon/RconTests.java
+++ b/src/test/java/nl/vv32/rcon/RconTests.java
@@ -67,6 +67,19 @@ public class RconTests {
         assertThrows(IllegalStateException.class, () -> rcon.authenticate("password"));
     }
 
+    // See issue #3
+    @Test
+    void authenticateCsgo() throws IOException {
+        Rcon rcon = new RconBuilder().withChannel(new RconServerSimulator().setPassword("password").doCsgoAuthentication()).build();
+        assertTrue(rcon.authenticate("password"));
+    }
+
+    @Test
+    void authenticateCsgoWrongPassword() throws IOException {
+        Rcon rcon = new RconBuilder().withChannel(new RconServerSimulator().setPassword("password").doCsgoAuthentication()).build();
+        assertFalse(rcon.authenticate("wrongPassword"));
+    }
+
     @Test
     void sendCommand() throws IOException {
         Rcon rcon = new RconBuilder().withChannel(new RconServerSimulator().setPassword("password")).build();


### PR DESCRIPTION
CS:GO sends a `SERVERDATA_RESPONSES_VALUE` in response to `SERVERDATA_AUTH_RESPONSE`, before it sends the `SERVERDATA_AUTH_RESPONSE`. This changes works around that quirk by receiving another packet if the first is a `SERVERDATA_RESPONSES_VALUE`.

I discovered this through packet sniffing, and cross-referencing with a [know working implementation](https://github.com/james4k/rcon/blob/master/rcon.go#L64:L69)